### PR TITLE
Make sure external references are correctly registered

### DIFF
--- a/src/Piral.Blazor.Core/JSBridge.cs
+++ b/src/Piral.Blazor.Core/JSBridge.cs
@@ -14,12 +14,17 @@ namespace Piral.Blazor.Core
 
         public static ModuleContainerService ContainerService { get; set; }
 
+        private static HttpClient _client;
+        
+        public static void Configure(HttpClient client)
+        {
+            _client = client;
+        }
+        
         [JSInvokable]
         public static async Task LoadComponentsFromLibrary(string url)
         {
-            var client  = new HttpClient();
-            byte[] data = await client.GetByteArrayAsync(url);
-            
+            byte[] data = await _client.GetByteArrayAsync(url);
             LoadComponents(data);
         }
 

--- a/src/Piral.Blazor.Core/JSBridge.cs
+++ b/src/Piral.Blazor.Core/JSBridge.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -14,10 +15,12 @@ namespace Piral.Blazor.Core
         public static ModuleContainerService ContainerService { get; set; }
 
         [JSInvokable]
-        public static Task LoadComponentsFromLibrary(string data)
+        public static async Task LoadComponentsFromLibrary(string url)
         {
-            LoadComponents(Convert.FromBase64String(data));
-            return Task.FromResult(true);
+            var client  = new HttpClient();
+            byte[] data = await client.GetByteArrayAsync(url);
+            
+            LoadComponents(data);
         }
 
         [JSInvokable]

--- a/src/Piral.Blazor.Core/Piral.Blazor.Core.csproj
+++ b/src/Piral.Blazor.Core/Piral.Blazor.Core.csproj
@@ -13,7 +13,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <BlazorEnableCompression>false</BlazorEnableCompression>
-    <BlazorWebAssemblyEnableLinking>true</BlazorWebAssemblyEnableLinking>
+    <BlazorWebAssemblyEnableLinking>false</BlazorWebAssemblyEnableLinking>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Piral.Blazor.Core/Program.cs
+++ b/src/Piral.Blazor.Core/Program.cs
@@ -21,7 +21,16 @@ namespace Piral.Blazor.Core
                 .AddSingleton<IComponentActivationService, ComponentActivationService>()
                 .AddSingleton<IModuleContainerService, ModuleContainerService>();
 
-            await builder.Build().RunAsync();
+            var host = builder.Build();
+
+            Configure(host);
+            
+            await host.RunAsync();
+        }
+
+        private static void Configure(WebAssemblyHost host)
+        {
+            JSBridge.Configure(host.Services.GetRequiredService<HttpClient>());
         }
     }
 }


### PR DESCRIPTION
- Disabled the linker. This tree shaking would give errors with the registration of dependencies in pilets (e.g. `System.Reflection`, ...)
- Fetched the components via URL instead of receiving a blob. (blobs >2MB would error out in Blazor < 5.0 )
  - This is a breaking change for `piral-blazor`, however! I opened a PR there: [piral#370](https://github.com/smapiot/piral/pull/370)