### PR TITLE
Page directive registration

### DIFF
--- a/src/Piral.Blazor.Analyzer/Extensions.cs
+++ b/src/Piral.Blazor.Analyzer/Extensions.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Piral.Blazor.Analyzer
+{
+    internal static class Extensions
+    {
+        internal static IReadOnlyCollection<string> GetAttributeValues
+        (
+            this IEnumerable<CustomAttributeData> attributeData,
+            string attributeName
+        )
+        {
+            return attributeData
+                .Where(ad => ad.AttributeType.Name.Equals(attributeName))
+                .SelectMany(ad => ad.ConstructorArguments)
+                .Where(ca => ca.Value is string)
+                .Select(ca => ca.Value as string)
+                .ToReadOnly();
+        }
+
+        internal static IReadOnlyCollection<CustomAttributeData> GetAllAttributeData(this Assembly assembly)
+        {
+            return assembly
+                .GetTypes()
+                .SelectMany(t => t.GetCustomAttributesData())
+                .ToReadOnly();
+        }
+
+        internal static IReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> source)
+        {
+            return source.ToList().AsReadOnly();
+        }
+    }
+}

--- a/src/Piral.Blazor.Analyzer/Loader.cs
+++ b/src/Piral.Blazor.Analyzer/Loader.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Piral.Blazor.Analyzer
+{
+    [Serializable]
+    internal class Loader : MarshalByRefObject
+    {
+        internal static string LoadFromDirectoryName { get; set; }
+
+        internal static Assembly LoadDependency(object sender, ResolveEventArgs args)
+        {
+            Assembly assembly = null;
+            try
+            {
+                assembly = Assembly.LoadFile(FileNameFromAssemblyName(args.Name));
+            }
+            catch { }
+
+            return assembly;
+        }
+
+        private static string FileNameFromAssemblyName(string p)
+        {
+            return Path.Combine(LoadFromDirectoryName, p.Split(',')[0] + ".dll");
+        }
+    }
+}

--- a/src/Piral.Blazor.Analyzer/Options.cs
+++ b/src/Piral.Blazor.Analyzer/Options.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Piral.Blazor.Analyzer
+{
+    internal readonly struct Options
+    {
+        public string BaseDir { get; }
+        public string Dir { get; }
+        public string DllName { get; }
+        public string DllPath { get; }
+
+        public Options(IReadOnlyList<string> args)
+        {
+            BaseDir = args[0];
+            DllName = args[1];
+
+            Dir = Path.GetFullPath(Path.Combine(BaseDir, "bin", "Release", "netstandard2.1"));
+            DllPath = Path.Combine(Dir, DllName);
+        }
+    }
+}

--- a/src/Piral.Blazor.Analyzer/Piral.Blazor.Analyzer.csproj
+++ b/src/Piral.Blazor.Analyzer/Piral.Blazor.Analyzer.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <RootNamespace>Piral.Blazor.Analyzer</RootNamespace>
+    </PropertyGroup>
+
+</Project>

--- a/src/Piral.Blazor.Analyzer/Program.cs
+++ b/src/Piral.Blazor.Analyzer/Program.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Piral.Blazor.Analyzer
+{
+    internal readonly struct Options
+    {
+        public string BaseDir { get; }
+        public string Dir { get; }
+        public string DllName { get; }
+        public string DllPath { get; }
+
+        public Options(IReadOnlyList<string> args)
+        {
+            BaseDir = args[0];
+            DllName = args[1];
+
+            Dir = Path.GetFullPath(Path.Combine(BaseDir, "bin", "Release", "netstandard2.1"));
+            DllPath = Path.Combine(Dir, DllName);
+        }
+    }
+
+    internal static class Program
+    {
+        internal static void Main(string[] args)
+        {
+            var options = new Options(args);
+
+            Loader.LoadFromDirectoryName = options.Dir;
+            AppDomain.CurrentDomain.AssemblyResolve += Loader.LoadDependency;
+            AppDomain.CurrentDomain.TypeResolve += Loader.LoadDependency;
+
+            var attributeData = Assembly
+                .LoadFrom(options.DllPath)
+                .GetTypes()
+                .SelectMany(t => t.GetCustomAttributesData())
+                .ToReadOnly();
+
+            var pages = attributeData.GetAttributeValues("RouteAttribute");
+            Console.WriteLine(JsonSerializer.Serialize(new { pages }));
+        }
+    }
+
+    internal static class Extensions
+    {
+        internal static IReadOnlyCollection<string> GetAttributeValues
+        (
+            this IEnumerable<CustomAttributeData> attributeData,
+            string attributeName
+        )
+        {
+            return attributeData
+                .Where(ad => ad.AttributeType.Name.Equals(attributeName))
+                .SelectMany(ad => ad.ConstructorArguments)
+                .Where(ca => ca.Value is string)
+                .Select(ca => ca.Value as string)
+                .ToReadOnly();
+        }
+
+        internal static IReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> source)
+        {
+            return source.ToList().AsReadOnly();
+        }
+    }
+
+    [Serializable]
+    internal class Loader : MarshalByRefObject
+    {
+        internal static string LoadFromDirectoryName { get; set; }
+
+        internal static Assembly LoadDependency(object sender, ResolveEventArgs args)
+        {
+            Assembly assembly = null;
+            try
+            {
+                assembly = Assembly.LoadFile(FileNameFromAssemblyName(args.Name));
+            }
+            catch { }
+
+            return assembly;
+        }
+
+        private static string FileNameFromAssemblyName(string p)
+        {
+            return Path.Combine(LoadFromDirectoryName, p.Split(',')[0] + ".dll");
+        }
+    }
+}

--- a/src/Piral.Blazor.Analyzer/Program.cs
+++ b/src/Piral.Blazor.Analyzer/Program.cs
@@ -1,92 +1,30 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 
 namespace Piral.Blazor.Analyzer
 {
-    internal readonly struct Options
-    {
-        public string BaseDir { get; }
-        public string Dir { get; }
-        public string DllName { get; }
-        public string DllPath { get; }
-
-        public Options(IReadOnlyList<string> args)
-        {
-            BaseDir = args[0];
-            DllName = args[1];
-
-            Dir = Path.GetFullPath(Path.Combine(BaseDir, "bin", "Release", "netstandard2.1"));
-            DllPath = Path.Combine(Dir, DllName);
-        }
-    }
-
     internal static class Program
     {
         internal static void Main(string[] args)
         {
             var options = new Options(args);
-
-            Loader.LoadFromDirectoryName = options.Dir;
-            AppDomain.CurrentDomain.AssemblyResolve += Loader.LoadDependency;
-            AppDomain.CurrentDomain.TypeResolve += Loader.LoadDependency;
+            
+            SetupLoader(options.Dir);
 
             var attributeData = Assembly
                 .LoadFrom(options.DllPath)
-                .GetTypes()
-                .SelectMany(t => t.GetCustomAttributesData())
-                .ToReadOnly();
-
+                .GetAllAttributeData();
+            
             var pages = attributeData.GetAttributeValues("RouteAttribute");
             Console.WriteLine(JsonSerializer.Serialize(new { pages }));
         }
-    }
 
-    internal static class Extensions
-    {
-        internal static IReadOnlyCollection<string> GetAttributeValues
-        (
-            this IEnumerable<CustomAttributeData> attributeData,
-            string attributeName
-        )
+        private static void SetupLoader(string directory)
         {
-            return attributeData
-                .Where(ad => ad.AttributeType.Name.Equals(attributeName))
-                .SelectMany(ad => ad.ConstructorArguments)
-                .Where(ca => ca.Value is string)
-                .Select(ca => ca.Value as string)
-                .ToReadOnly();
-        }
-
-        internal static IReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> source)
-        {
-            return source.ToList().AsReadOnly();
-        }
-    }
-
-    [Serializable]
-    internal class Loader : MarshalByRefObject
-    {
-        internal static string LoadFromDirectoryName { get; set; }
-
-        internal static Assembly LoadDependency(object sender, ResolveEventArgs args)
-        {
-            Assembly assembly = null;
-            try
-            {
-                assembly = Assembly.LoadFile(FileNameFromAssemblyName(args.Name));
-            }
-            catch { }
-
-            return assembly;
-        }
-
-        private static string FileNameFromAssemblyName(string p)
-        {
-            return Path.Combine(LoadFromDirectoryName, p.Split(',')[0] + ".dll");
+            Loader.LoadFromDirectoryName = directory;
+            AppDomain.CurrentDomain.AssemblyResolve += Loader.LoadDependency;
+            AppDomain.CurrentDomain.TypeResolve += Loader.LoadDependency;
         }
     }
 }

--- a/src/Piral.Blazor.Core/ComponentActivationService.cs
+++ b/src/Piral.Blazor.Core/ComponentActivationService.cs
@@ -95,10 +95,9 @@ namespace Piral.Blazor.Core
             
             foreach (var componentType in componentTypes)
             {
-                var toRegister = GetComponentNamesToRegister(componentType, AttributeTypes);
-                foreach (string componentName in toRegister)
+                var componentNames = GetComponentNamesToRegister(componentType, AttributeTypes);
+                foreach (var componentName in componentNames)
                 {
-                    if (componentName is null) continue;
                     Register(componentName, componentType, serviceProvider);
                     _logger.LogInformation($"registered {componentName}");
                 }
@@ -111,7 +110,7 @@ namespace Piral.Blazor.Core
         /// </summary>
         private static string Sanitize(string value)
         {
-            string val = value.StartsWith("/") ? value.Substring(1) : value;
+            var val = value.StartsWith("/") ? value.Substring(1) : value;
             return Regex.Replace(val, @"[^\w\-]+", "_");
         }
 
@@ -131,7 +130,7 @@ namespace Piral.Blazor.Core
             switch (attributeType)
             {
                 case Type _ when attributeType == typeof(RouteAttribute):
-                    string template = member.GetCustomAttribute<RouteAttribute>(false)?.Template;
+                    var template = member.GetCustomAttribute<RouteAttribute>(false)?.Template;
                     return template is null
                         ? null
                         : $"page-{Sanitize(template)}"; //pages have a "page-" prefix and get sanitized

--- a/src/Piral.Blazor.Core/ComponentActivationService.cs
+++ b/src/Piral.Blazor.Core/ComponentActivationService.cs
@@ -112,7 +112,7 @@ namespace Piral.Blazor.Core
         private static string Sanitize(string value)
         {
             string val = value.StartsWith("/") ? value.Substring(1) : value;
-            return Regex.Replace(val, @"[^\w\-]", "_");
+            return Regex.Replace(val, @"[^\w\-]+", "_");
         }
 
         private Type GetComponent(string componentName)

--- a/src/Piral.Blazor.Core/ComponentActivationService.cs
+++ b/src/Piral.Blazor.Core/ComponentActivationService.cs
@@ -64,8 +64,16 @@ namespace Piral.Blazor.Core
         public void ActivateComponent(string componentName, string referenceId, IDictionary<string, object> args)
         {
             var component = GetComponent(componentName);
-            _active.Add(new ActiveComponent(componentName, referenceId, component, args));
-            Changed?.Invoke(this, EventArgs.Empty);
+            try
+            {
+                _active.Add(new ActiveComponent(componentName, referenceId, component, args));
+                Changed?.Invoke(this, EventArgs.Empty);
+            }
+            catch (ArgumentException ae)
+            {
+                _logger.LogError($"One of the arguments is invalid: {ae.Message}");
+            }
+
         }
 
         public void DeactivateComponent(string componentName, string referenceId)

--- a/src/Piral.Blazor.Core/Extensions.cs
+++ b/src/Piral.Blazor.Core/Extensions.cs
@@ -18,7 +18,7 @@ namespace Piral.Blazor.Core
         {
             public IDictionary<string, object> @params { get; set; }
         }
-        
+
         public static IDictionary<string, object> AdjustArguments(this Type type, IDictionary<string, object> args)
         {
             if (!allowedArgs.TryGetValue(type, out var allowed))
@@ -31,22 +31,26 @@ namespace Piral.Blazor.Core
                 allowedArgs.Add(type, allowed);
             }
 
-            var allArgs = new List<IDictionary<string, object>> {args};
+            var allArgs = new List<IDictionary<string, object>> { args };
             try
             {
                 var routeParams = JsonSerializer.Deserialize<Match>(JsonSerializer.Serialize(args["match"]))?.@params;
-                if(!routeParams.IsNullOrEmpty()) allArgs.Add(routeParams);
+                
+                if (!routeParams.IsNullOrEmpty())
+                {
+                    allArgs.Add(routeParams);
+                }
             }
-            catch(KeyNotFoundException) { }
+            catch (KeyNotFoundException) { }
 
             var adjustedArgs = allArgs
                 .SelectMany(dict => dict)
                 .Where(m => allowed.Contains(m.Key))
                 .ToDictionary(m => m.Key, m => type.NormalizeValue(m.Key, m.Value));
-            
+
             return adjustedArgs;
         }
-        
+
         public static object NormalizeValue(this Type type, string key, object value)
         {
             var property = type.GetProperty(key);

--- a/src/Piral.Blazor.Core/Extensions.cs
+++ b/src/Piral.Blazor.Core/Extensions.cs
@@ -13,13 +13,6 @@ namespace Piral.Blazor.Core
     static class Extensions
     {
         private static readonly IDictionary<Type, string[]> allowedArgs = new Dictionary<Type, string[]>();
-        
-        private static ILogger _logger;
-
-        public static void Configure(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger(typeof(Extensions));
-        }
 
         private class Match
         {
@@ -90,21 +83,6 @@ namespace Piral.Blazor.Core
             else
             {
                 return null;
-            }
-        }
-
-        public static bool HasExplicitFlag(this IDictionary<string, object> args, bool expectedValue, string option)
-        {
-            if (args.IsNullOrEmpty()) return false;
-            try
-            {
-                return args.TryGetValue(option, out var value) && ((JsonElement) value).GetBoolean() == expectedValue;
-            }
-            catch
-            {
-                _logger.LogWarning(
-                    $"The '{option}' option is not set correctly. It should be either 'true' or 'false'.");
-                return false;
             }
         }
 

--- a/src/Piral.Blazor.Core/Extensions.cs
+++ b/src/Piral.Blazor.Core/Extensions.cs
@@ -58,40 +58,27 @@ namespace Piral.Blazor.Core
         {
             var property = type.GetProperty(key);
             var propType = property.PropertyType;
-            
-            if (value == null) return propType.GetDefaultValue();
-            if (value.GetType() == propType) return value;
-            if (!(value is JsonElement e)) return value;
-            
-            if (propType == typeof(int))
+
+            if (value == null)
             {
-                if (e.ValueKind == JsonValueKind.Number) return e.GetInt32();
-                if (e.ValueKind == JsonValueKind.String) return int.Parse(e.GetString());
-            }
-            else if (propType == typeof(double))
-            {
-                if (e.ValueKind == JsonValueKind.Number) return e.GetDouble();
-                if (e.ValueKind == JsonValueKind.String) return double.Parse(e.GetString());
-            }
-            else if (propType == typeof(string))
-            {
-                return e.GetString();
-            }
-            else if (propType == typeof(bool))
-            {
-                if (e.ValueKind == JsonValueKind.True || e.ValueKind == JsonValueKind.False) return e.GetBoolean();
-                if (e.ValueKind == JsonValueKind.String) return bool.Parse(e.GetString());
-            }
-            else if (propType == typeof(Guid))
-            {
-                return e.GetGuid();
-            }
-            else if (propType == typeof(DateTime))
-            {
-                return e.GetDateTime();
+                return propType.GetDefaultValue();
             }
 
-            return value;
+            if (value.GetType() == propType)
+            {
+                return value;
+            }
+
+            return value switch
+            {
+                JsonElement e when propType == typeof(int) => e.GetInt32(),
+                JsonElement e when propType == typeof(double) => e.GetDouble(),
+                JsonElement e when propType == typeof(string) => e.GetString(),
+                JsonElement e when propType == typeof(bool) => e.GetBoolean(),
+                JsonElement e when propType == typeof(Guid) => e.GetGuid(),
+                JsonElement e when propType == typeof(DateTime) => e.GetDateTime(),
+                _ => value
+            };
         }
 
         public static object GetDefaultValue(this Type t)

--- a/src/Piral.Blazor.Core/JSBridge.cs
+++ b/src/Piral.Blazor.Core/JSBridge.cs
@@ -35,11 +35,11 @@ namespace Piral.Blazor.Core
         }
 
         [JSInvokable]
-        public static async Task LoadComponentsFromLibrary(string url, IDictionary<string, object> args = default)
+        public static async Task LoadComponentsFromLibrary(string url)
         {
             var data = await _client.GetByteArrayAsync(url);
             var assembly = Assembly.Load(data);
-            ActivationService?.LoadComponentsFromAssembly(assembly, args);
+            ActivationService?.LoadComponentsFromAssembly(assembly);
         }
 
         [JSInvokable]

--- a/src/Piral.Blazor.Core/JSBridge.cs
+++ b/src/Piral.Blazor.Core/JSBridge.cs
@@ -22,10 +22,10 @@ namespace Piral.Blazor.Core
         }
         
         [JSInvokable]
-        public static async Task LoadComponentsFromLibrary(string url)
+        public static async Task LoadComponentsFromLibrary(string url, IDictionary<string, object> args = default)
         {
             byte[] data = await _client.GetByteArrayAsync(url);
-            LoadComponents(data);
+            LoadComponents(data, args);
         }
 
         [JSInvokable]
@@ -50,12 +50,12 @@ namespace Piral.Blazor.Core
             return Task.FromResult(true);
         }
 
-        private static void LoadComponents(byte[] content)
+        private static void LoadComponents(byte[] content, IDictionary<string, object> args = default)
         {
             var assembly = Assembly.Load(content);
             UnloadComponents(assembly.FullName);
             var container = ContainerService?.Configure(assembly);
-            ActivationService?.RegisterAll(assembly, container);
+            ActivationService?.RegisterAll(assembly, container, args);
         }
 
         private static void UnloadComponents(string name)

--- a/src/Piral.Blazor.Core/JSBridge.cs
+++ b/src/Piral.Blazor.Core/JSBridge.cs
@@ -35,11 +35,11 @@ namespace Piral.Blazor.Core
         }
 
         [JSInvokable]
-        public static async Task LoadComponentsFromLibrary(string url)
+        public static async Task LoadComponentsFromLibrary(string url, IDictionary<string, object> args = default)
         {
             var data = await _client.GetByteArrayAsync(url);
             var assembly = Assembly.Load(data);
-            ActivationService?.LoadComponentsFromAssembly(assembly);
+            ActivationService?.LoadComponentsFromAssembly(assembly, args);
         }
 
         [JSInvokable]

--- a/src/Piral.Blazor.Core/Program.cs
+++ b/src/Piral.Blazor.Core/Program.cs
@@ -32,7 +32,6 @@ namespace Piral.Blazor.Core
         private static void Configure(WebAssemblyHost host)
         {
             JSBridge.Configure(host.Services.GetRequiredService<HttpClient>());
-            Extensions.Configure(host.Services.GetService<ILoggerFactory>());
         }
     }
 }

--- a/src/Piral.Blazor.Core/Program.cs
+++ b/src/Piral.Blazor.Core/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Piral.Blazor.Core
 {
@@ -31,6 +32,7 @@ namespace Piral.Blazor.Core
         private static void Configure(WebAssemblyHost host)
         {
             JSBridge.Configure(host.Services.GetRequiredService<HttpClient>());
+            Extensions.Configure(host.Services.GetService<ILoggerFactory>());
         }
     }
 }

--- a/src/Piral.Blazor.sln
+++ b/src/Piral.Blazor.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piral.Blazor.Template", "Pi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piral.Blazor.Tools", "Piral.Blazor.Tools\Piral.Blazor.Tools.csproj", "{7223A622-A5F6-40F2-8642-FF5850249392}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piral.Blazor.Analyzer", "Piral.Blazor.Analyzer\Piral.Blazor.Analyzer.csproj", "{B158A713-50AE-498F-8746-1F63CBB656C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{7223A622-A5F6-40F2-8642-FF5850249392}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7223A622-A5F6-40F2-8642-FF5850249392}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7223A622-A5F6-40F2-8642-FF5850249392}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B158A713-50AE-498F-8746-1F63CBB656C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B158A713-50AE-498F-8746-1F63CBB656C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B158A713-50AE-498F-8746-1F63CBB656C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B158A713-50AE-498F-8746-1F63CBB656C3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is related to #4.

This change makes sure one could write
```ts
export function setup(api) {
  api.defineBlazorReferences([...], {
    includePages: true, //set to false or omit to not auto discover
  });
}
```

All components marked with a `@page` directive will then be registered. They will also pick up route parameters through `args.match.params` if possible.

Their names are sanitized: Any leading slashes are removed and everything that is not alphanumeric, an underscore, or a dash gets replaced with an underscore. This is important to know for the creation of a codegen that will register all names on compile time, later. 
