### PR TITLE
Add PiralComponent and PiralExtensions attributes

### DIFF
--- a/src/Piral.Blazor.Template/content/SamplePage.razor
+++ b/src/Piral.Blazor.Template/content/SamplePage.razor
@@ -1,4 +1,4 @@
-@attribute [ExposePilet("sample-page")]
+@attribute [PiralComponent("sample-page")]
 
 <div>
     <p>Current count: @counter</p>

--- a/src/Piral.Blazor.Utils/ExposePiletAttribute.cs
+++ b/src/Piral.Blazor.Utils/ExposePiletAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace Piral.Blazor.Utils
 {
+    [Obsolete("Please use the PiralComponent or PiralExtension attributes.")]
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class ExposePiletAttribute : Attribute
     {

--- a/src/Piral.Blazor.Utils/PiralComponentAttribute.cs
+++ b/src/Piral.Blazor.Utils/PiralComponentAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Piral.Blazor.Utils
+{
+    public sealed class PiralComponentAttribute : Attribute
+    {
+        /// <summary>
+        /// Registers a Piral component
+        /// </summary>
+        public PiralComponentAttribute() { }
+
+        /// <summary>
+        /// Registers a Piral component using a custom name
+        /// </summary>
+        public PiralComponentAttribute(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Gets the name of the component in the pilet.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/Piral.Blazor.Utils/PiralExtensionAttribute.cs
+++ b/src/Piral.Blazor.Utils/PiralExtensionAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Piral.Blazor.Utils
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class PiralExtensionAttribute : Attribute
+    {
+        /// <summary>
+        /// Registers a Piral extension for a specific extensionId
+        /// </summary>
+        public PiralExtensionAttribute(string extensionId)
+        {
+            ExtensionId = extensionId;
+        }
+
+        /// <summary>
+        /// The extension id provided. This has to correspond to the name of an extension slot.
+        /// </summary>
+        public string ExtensionId { get; }
+    }
+}


### PR DESCRIPTION
#### PiralComponent
- `[PiralComponent]` 
  - component gets registered via fully qualified name (FQN)
  - user can use `app.fromBlazor( "${FQN}" )`
- `[PiralComponent("my-component"`)
  - component gets registered with name `"my-component"`
  - user can use `app.fromBlazor("my-component")`

#### PiralExtension
- `[PiralExtension("my-slotname")]`
  - extension get registered via fully qualified name (FQN) for use in an extensionslot with name "my-slotname"
  - this should then translate in the codegen to `app.registerExtension("my-slotname", app.fromBlazor( "${FQN}" ))`
