### PR TITLE
Define reference id + update Piral.Blazor.Analyzer to detect extensions

### DIFF
--- a/src/Piral.Blazor.Analyzer/Extensions.cs
+++ b/src/Piral.Blazor.Analyzer/Extensions.cs
@@ -21,9 +21,9 @@ namespace Piral.Blazor.Analyzer
                 .ToReadOnly();
         }
 
-        internal static Dictionary<string, IReadOnlyCollection<string>> MapAttributeValuesFor
+        internal static IDictionary<string, IReadOnlyCollection<string>> MapAttributeValuesFor
         (
-            this IReadOnlyCollection<Type> types,
+            this IEnumerable<Type> types,
             string attributeName
         )
         {

--- a/src/Piral.Blazor.Analyzer/Extensions.cs
+++ b/src/Piral.Blazor.Analyzer/Extensions.cs
@@ -1,32 +1,38 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace Piral.Blazor.Analyzer
 {
     internal static class Extensions
     {
-        internal static IReadOnlyCollection<string> GetAttributeValues
+        internal static IReadOnlyCollection<string> GetFirstAttributeValue
         (
-            this IEnumerable<CustomAttributeData> attributeData,
+            this Type type,
             string attributeName
         )
         {
-            return attributeData
+            return type
+                .GetCustomAttributesData()
                 .Where(ad => ad.AttributeType.Name.Equals(attributeName))
-                .SelectMany(ad => ad.ConstructorArguments)
+                .Select(ad => ad.ConstructorArguments.FirstOrDefault())
                 .Where(ca => ca.Value is string)
                 .Select(ca => ca.Value as string)
                 .ToReadOnly();
         }
 
-        internal static IReadOnlyCollection<CustomAttributeData> GetAllAttributeData(this Assembly assembly)
+        internal static Dictionary<string, IReadOnlyCollection<string>> MapAttributeValuesFor
+        (
+            this IReadOnlyCollection<Type> types,
+            string attributeName
+        )
         {
-            return assembly
-                .GetTypes()
-                .SelectMany(t => t.GetCustomAttributesData())
-                .ToReadOnly();
+            return types
+                .ToDictionary(t => t.FullName, t => t.GetFirstAttributeValue(attributeName))
+                .Where(kvp => kvp.Value.Count > 0)
+                .ToDictionary(x => x.Key, x => x.Value);
         }
+
 
         internal static IReadOnlyCollection<T> ToReadOnly<T>(this IEnumerable<T> source)
         {

--- a/src/Piral.Blazor.Analyzer/Program.cs
+++ b/src/Piral.Blazor.Analyzer/Program.cs
@@ -23,13 +23,12 @@ namespace Piral.Blazor.Analyzer
             Console.WriteLine(JsonSerializer.Serialize(new { routes, extensions }));
         }
 
-        private static Dictionary<string, IReadOnlyCollection<string>> ExtractExtensions(Type[] types)
+        private static IDictionary<string, IReadOnlyCollection<string>> ExtractExtensions(Type[] types)
         {
-            var extensions = types.MapAttributeValuesFor("PiralExtensionAttribute");
-            return extensions;
+            return types.MapAttributeValuesFor("PiralExtensionAttribute");
         }
 
-        private static IEnumerable<string> ExtractRoutes(Type[] types)
+        private static IEnumerable<string> ExtractRoutes(IEnumerable<Type> types)
         {
             return types.SelectMany(t => t.GetFirstAttributeValue("RouteAttribute"));
         }

--- a/src/Piral.Blazor.Core/App.razor
+++ b/src/Piral.Blazor.Core/App.razor
@@ -3,7 +3,7 @@
 
 @foreach (var active in Activation.Components)
 {
-    <div id="@active.ComponentName-@active.ReferenceId">
+    <div id="@active.ReferenceId">
         <div>
             @{
                 RenderFragment renderFragment = (builder) =>

--- a/src/Piral.Blazor.Core/ComponentActivationService.cs
+++ b/src/Piral.Blazor.Core/ComponentActivationService.cs
@@ -3,9 +3,7 @@ using Piral.Blazor.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http.Headers;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components;
 
 namespace Piral.Blazor.Core
@@ -112,16 +110,6 @@ namespace Piral.Blazor.Core
                     _logger.LogInformation($"registered {componentName}");
                 }
             }
-        }
-
-        /// <summary>
-        /// Sanitizing a Blazor component name. Any leading slashes are removed and
-        /// everything that is not alphanumeric, an underscore or a dash gets replaced with an underscore.
-        /// </summary>
-        private static string Sanitize(string value)
-        {
-            var val = value.StartsWith("/") ? value.Substring(1) : value;
-            return Regex.Replace(val, @"[^\w\-]+", "_");
         }
 
         private Type GetComponent(string componentName)

--- a/src/Piral.Blazor.Core/ComponentActivationService.cs
+++ b/src/Piral.Blazor.Core/ComponentActivationService.cs
@@ -139,7 +139,7 @@ namespace Piral.Blazor.Core
             return attributeType switch
             {
                 Type _ when attributeType == typeof(RouteAttribute) =>
-                    $"page-{Sanitize(((RouteAttribute) attribute).Template)}",
+                    $"page-{((RouteAttribute) attribute).Template}",
                 Type _ when attributeType == typeof(PiralExtensionAttribute) => 
                     $"extension-{member.FullName}",
                 Type _ when attributeType == typeof(PiralComponentAttribute) =>

--- a/src/Piral.Blazor.Core/JSBridge.cs
+++ b/src/Piral.Blazor.Core/JSBridge.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Piral.Blazor.Core
@@ -22,7 +23,8 @@ namespace Piral.Blazor.Core
         [JSInvokable]
         public static Task<string> Activate(string componentName, IDictionary<string, object> args)
         {
-            var referenceId = Guid.NewGuid().ToString().Split('-').Last();
+            var guidSegment = Guid.NewGuid().ToString().Split('-').Last();
+            var referenceId = $"piral-blazor-{Sanitize(componentName)}-{guidSegment}";
             ActivationService?.ActivateComponent(componentName, referenceId, args);
             return Task.FromResult(referenceId);
         }
@@ -49,6 +51,12 @@ namespace Piral.Blazor.Core
             var pdb = await _client.GetByteArrayAsync(pdbUrl);
             var assembly = Assembly.Load(dll, pdb);
             ActivationService?.LoadComponentsFromAssembly(assembly);
+        }
+        
+        /// <summary>Every series of characters that is not alphanumeric gets consolidated into a dash</summary>
+        private static string Sanitize(string value)
+        {
+            return Regex.Replace(value, @"[^a-zA-Z0-9]+", "-");
         }
     }
 }


### PR DESCRIPTION
#### referenceId
This is a change linked to smapiot/piral#374.

#### Piral.Blazor.Analyzer
Running the `Piral.Blazor.Analyzer` like so: 
```bash
dotnet run path/to/Blazor/pilet Blazor.Pilet.dll
```

Will produce
```js
{
  "routes": ["/list", "/of", "/routes",  /*...*/ ],
  "extensions": {
    "Blazor.Pilet.Component1": [ "slotname-1", "another-slotname", /*...*/ ],
    //...
  }
}
```

on stdout.