### PR TITLE
Allow multiple PiralExtension attributes

### DIFF
--- a/src/Piral.Blazor.Core/ComponentActivationService.cs
+++ b/src/Piral.Blazor.Core/ComponentActivationService.cs
@@ -125,17 +125,18 @@ namespace Piral.Blazor.Core
 
         private static string GetComponentNameToRegister(Type member, Type attributeType)
         {
-            // Equivalent to member.GetCustomAttribute< *attributeType* >(inherit: false);
-            var attribute = typeof(CustomAttributeExtensions)
-                .GetMethod("GetCustomAttribute", new[] { typeof(MemberInfo), typeof(bool) })
-                ?.MakeGenericMethod(attributeType)
-                .Invoke(member, new object[] { member, false });
-
+            // get only the first occurence of the attribute.
+            // This is only relevant for extensions, which can have multiple attributes,
+            // but the name to register (FQN) will be the same for every occurence anyway.
+            var attribute = member
+                .GetCustomAttributes(attributeType, false)
+                .FirstOrDefault(); 
+            
             if (attribute is null)
             {
                 return null;
             }
-
+            
             return attributeType switch
             {
                 Type _ when attributeType == typeof(RouteAttribute) =>

--- a/src/Piral.Blazor.Utils/PiralExtensionAttribute.cs
+++ b/src/Piral.Blazor.Utils/PiralExtensionAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Piral.Blazor.Utils
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class PiralExtensionAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
For when we want to render the component in multiple slots with different names. 
This will register the component with Piral.Blazor.Core only once (which is good), but the analyzer can pick up all the extensionIds!