### PR TITLE
Documentation (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,62 @@
-# Piral.Blazor
+[![Piral Logo](https://github.com/smapiot/piral/raw/master/docs/assets/logo.png)](https://piral.io)
 
-[![Build Status](https://florianrappl.visualstudio.com/Piral.Blazor/_apis/build/status/FlorianRappl.Piral.Blazor?branchName=master)](https://florianrappl.visualstudio.com/Piral.Blazor/_build/latest?definitionId=27&branchName=master)
+# Piral.Blazor &middot; [![GitHub License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/smapiot/piral.blazor/blob/master/LICENSE) [![Build Status](https://smapiot.visualstudio.com/piral-pipelines/_apis/build/status/smapiot.piral.blazor?branchName=blazor-5.0)](https://smapiot.visualstudio.com/piral-pipelines/_build/latest?definitionId=48&branchName=blazor-5.0) [![GitHub Tag](https://img.shields.io/github/tag/smapiot/Piral.Blazor.svg)](https://github.com/smapiot/Piral.Blazor/releases) [![GitHub Issues](https://img.shields.io/github/issues/smapiot/piral.svg)](https://github.com/smapiot/piral/issues) [![Gitter Chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/piral-io/community) [![Feed Status](https://img.shields.io/uptimerobot/status/m783654792-cfe3913c7481e0f44c143f63)](https://status.piral.io/)
 
-All things to make Blazor work seamlessly in microfrontends using Piral.
-
-## Template
-
-Make sure that you've installed the template.
-
-```sh
-dotnet new -i Piral.Blazor.Template
-```
-
-Create a new folder and run the template.
-
-```sh
-dotnet new blazorpilet
-```
+All .NET things to make <a href="https://blazor.net" rel="nofollow"><img
+src="https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2019/04/BrandBlazor_nohalo_1000x.png"
+height="10">&nbsp;Blazor</a> work seamlessly in microfrontends using
+<a href="https://piral.io" rel="nofollow">
+<img src="https://piral.io/logo-simple.f8667084.png" height="10">
+&nbsp;Piral</a>.
 
 ## Getting Started
 
-We are still in the process of making this accessible. Any contribution appreciated!
+> You'll also find some information in the [piral-blazor](https://www.npmjs.com/package/piral-blazor) package.
 
-(You'll also find some information on the [piral-blazor](https://www.npmjs.com/package/piral-blazor) package.)
+To create a Blazor pilet using Piral.Blazor, two approaches can be used:
+
+#### 1. Creating a Blazor pilet from scratch.
+
+In this case, it is highly recommended to use our template. More information and installation instructions can be found in [`Piral.Blazor.Template`](/src/Piral.Blazor.Template)
+
+#### 2. Transforming an existing Blazor application into a pilet
+
+In this case, follow these steps:
+
+1. Add a `PiralInstance` property to your `.csproj` file (The piral instance name should be the name of the piral instance you want to use, as it is published on npm.)
+
+   ```xml
+   <PropertyGroup>
+       <TargetFramework>net5.0</TargetFramework>
+       <PiralInstance>my-piral-instance</PiralInstance>
+   </PropertyGroup>
+   ```
+
+2. Install the `Piral.Blazor.Tools` and `Piral.Blazor.Utils` packages
+3. rename `Program.cs` to `Module.cs`, and make sure to make the `Main` method an empty method.
+4. Build the project. The first time you do this, this can take some time as it will fully scaffold the pilet.
 
 ## Usage
 
-You can expose your Blazor components using the `ExposePilet` attribute.
+### Pages
 
-```cs
-@attribute [ExposePilet("counter")]
+A standard page in Blazor, using the `@page` directive, will work as expected, and will be automatically registered on the pilet API.
 
-<h1>Counter from Lib A</h1>
+### Extensions
+
+To register an extension, the `PiralExtension` attribute can be used. You will also have to provide the extension slot name that defines where the extension should be rendered. The component can even be registered into multiple slots using multiple attributes.
+
+```razor
+//counter.razor
+
+@attribute [PiralExtension("my-counter-slot")]
+@attribute [PiralExtension("another-extension-slot")]
+
+<h1>Counter</h1>
 
 <p>Current count: @currentCount</p>
 
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+<button @onclick="IncrementCount">Click me</button>
 
 @code {
     int currentCount = 0;
@@ -47,9 +68,37 @@ You can expose your Blazor components using the `ExposePilet` attribute.
 }
 ```
 
-You can define services for dependency injection in a `Module` class. Actually, the name of the class is arbitrary, but it shows the difference to the standard `Program` class, which should not be available.
+To use an extension within a Blazor component, the `<Extension>` component can be used.
 
-To be able to compile it successfully a `Main` method should be declared, which should remain empty.
+```razor
+<Extension Name="my-counter-slot"></Extension>
+```
+
+### Components, tiles, menu items...
+
+To register a Blazor component for use in the pilet API, the `PiralComponent` attribute can be used in two ways:
+
+1. `[PiralComponent]`, this will register the component using the fully qualified name.
+2. `[PiralComponent(<name>)]` will register the component using the custom name provided.
+
+To register these components onto the pilet API, a `setup.tsx` file should be created at the root of your Blazor project.
+
+This file may then, for example to register a tile, look like this:
+
+```tsx
+import { PiletApi } from '../piral~/<project_name>/node_modules/<piral_instance>';
+
+export default (app: PiletApi) => {
+	//for a component marked with[PiralComponent("my-tile")]
+	app.registerTile(app.fromBlazor('my-tile'));
+};
+```
+
+### Dependency injection
+
+You can define services for dependency injection in a `Module` class. The name of the class is arbitrary, but it shows the difference to the standard `Program` class, which should not be available, as mentioned before.
+
+To be able to compile successfully, a `Main` method should be declared, which should remain empty.
 
 ```cs
 public class Module
@@ -66,4 +115,19 @@ public class Module
 }
 ```
 
-Use the `ConfigureServices` function to define dependency injection.
+## Running and debugging the pilet :rocket:
+
+From your blazor project folder, run your pilet via the piral CLI:
+
+```sh
+npx pilet debug --base ../piral~/<project-name>
+```
+
+In addition to this, if you want to debug your Blazor pilet using for example Visual Studio, these requirements should be considered:
+
+- keep the piral CLI running
+- debug your Blazor pilet using IISExpress
+
+## License
+
+Piral.Blazor is released using the MIT license. For more information see the [license file](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In this case, it is highly recommended to use our template. More information and
 
 In this case, follow these steps:
 
-1. Add a `PiralInstance` property to your `.csproj` file (The piral instance name should be the name of the piral instance you want to use, as it is published on npm.)
+1. Add a `PiralInstance` property to your `.csproj` file (The Piral instance name should be the name of the Piral instance you want to use, as it is published on npm.)
 
    ```xml
    <PropertyGroup>
@@ -117,7 +117,7 @@ public class Module
 
 ## Running and debugging the pilet :rocket:
 
-From your blazor project folder, run your pilet via the piral CLI:
+From your blazor project folder, run your pilet via the Piral CLI:
 
 ```sh
 npx pilet debug --base ../piral~/<project-name>
@@ -125,7 +125,7 @@ npx pilet debug --base ../piral~/<project-name>
 
 In addition to this, if you want to debug your Blazor pilet using for example Visual Studio, these requirements should be considered:
 
-- keep the piral CLI running
+- keep the Piral CLI running
 - debug your Blazor pilet using IISExpress
 
 ## License

--- a/src/Piral.Blazor.Template/README.md
+++ b/src/Piral.Blazor.Template/README.md
@@ -1,0 +1,24 @@
+# Piral.Blazor.Template
+
+[![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Piral.Blazor.Template)](https://www.nuget.org/packages?q=Piral.Blazor)
+
+For getting started easily, a Blazor template is available. This will set up a Blazor pilet for the preferred piral instance.
+
+### Installation
+
+- Make sure that [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) is installed.
+- Run `dotnet new --install Piral.Blazor.Template` to install the project template globally.
+
+### Usage
+
+Create a new folder in your solution (the folder name will be used as your
+project name) and run the template using
+
+```sh
+dotnet new blazorpilet --piralInstance <piral-instance-name>
+```
+
+The piral instance name should be the name of the piral instance as it is published on npm.
+
+Build the project. The first time you do this, this can take some time as it
+will scaffold the pilet.

--- a/src/Piral.Blazor.Template/README.md
+++ b/src/Piral.Blazor.Template/README.md
@@ -1,8 +1,8 @@
 # Piral.Blazor.Template
 
-[![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Piral.Blazor.Template)](https://www.nuget.org/packages?q=Piral.Blazor)
+[![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Piral.Blazor.Template)](https://www.nuget.org/packages/Piral.Blazor.Template)
 
-For getting started easily, a Blazor template is available. This will set up a Blazor pilet for the preferred piral instance.
+For getting started easily, a Blazor template is available. This will set up a Blazor pilet for the preferred Piral instance.
 
 ### Installation
 
@@ -18,7 +18,7 @@ project name) and run the template using
 dotnet new blazorpilet --piralInstance <piral-instance-name>
 ```
 
-The piral instance name should be the name of the piral instance as it is published on npm.
+The Piral instance name should be the name of the Piral instance as it is published on npm.
 
 Build the project. The first time you do this, this can take some time as it
 will scaffold the pilet.


### PR DESCRIPTION
Complete overhaul of the documentation in the form of a README. Tried to be in line with other existing Piral readmes.

Remarks:
- chose a reference to the `Piral.Blazor.Template` readme instead of cramming it in the main one.