### PR TITLE
Enable support for scoped razor styles

### DIFF
--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -81,10 +81,10 @@
 
     <Target Name="CopyScopedCss" AfterTargets="Build">
         <!-- Always create an empty one first to avoid breaking index.tsx -->
-        <Touch Files="$(_srcPath)\src" AlwaysCreate="true"/>
+        <Touch Files="$(_srcPath)\$(MSBuildProjectName).styles.css" AlwaysCreate="true"/>
         <Copy
                 SourceFiles="obj\$(Configuration)\$(TargetFrameWork)\scopedcss\bundle\$(MSBuildProjectName).styles.css"
-                DestinationFolder="$(_srcPath)\src"
+                DestinationFolder="$(_srcPath)"
                 Condition="Exists('obj\$(Configuration)\$(TargetFrameWork)\scopedcss\bundle\$(MSBuildProjectName).styles.css')"
         />
     </Target>

--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -45,7 +45,7 @@
         <Exec Command="echo 'Modifying the index file...'"/>
         <WriteLinesToFile
                 File="$(_srcPath)\index.tsx"
-                Lines="$([System.IO.File]::ReadAllText($(_srcPath)\index.tsx).Replace('**PiralInstance**','$(PiralInstance)'))"
+                Lines="$([System.IO.File]::ReadAllText($(_srcPath)\index.tsx).Replace('**PiralInstance**','$(PiralInstance)').Replace('**BlazorProjectName**','$(MSBuildProjectName)'))"
                 Overwrite="true"
                 Encoding="UTF-8"/>
     </Target>
@@ -78,8 +78,18 @@
                 Overwrite="true"
                 Encoding="UTF-8"/>
     </Target>
+
+    <Target Name="CopyScopedCss" AfterTargets="Build">
+        <!-- Always create an empty one first to avoid breaking index.tsx -->
+        <Touch Files="$(_srcPath)\src" AlwaysCreate="true"/>
+        <Copy
+                SourceFiles="obj\$(Configuration)\$(TargetFrameWork)\scopedcss\bundle\$(MSBuildProjectName).styles.css"
+                DestinationFolder="$(_srcPath)\src"
+                Condition="Exists('obj\$(Configuration)\$(TargetFrameWork)\scopedcss\bundle\$(MSBuildProjectName).styles.css')"
+        />
+    </Target>
     
-    <Target Name="HotReload" AfterTargets="Build">
+    <Target Name="HotReload" AfterTargets="CopyScopedCss">
         <Touch Files="$(_srcPath)\blazor.codegen" Condition="Exists('$(_srcPath)\blazor.codegen')"/>
     </Target>
     

--- a/src/Piral.Blazor.Tools/content/src/index.tsx
+++ b/src/Piral.Blazor.Tools/content/src/index.tsx
@@ -1,5 +1,6 @@
 import { PiletApi } from '**PiralInstance**';
 import * as Blazor from './blazor.codegen';
+import './**BlazorProjectName**.styles.css';
 
 export function setup(app: PiletApi) {
     Blazor.registerDependencies(app);


### PR DESCRIPTION
Blazor has a [CSS isolation](https://docs.microsoft.com/en-us/aspnet/core/blazor/components/css-isolation) feature. `*.razor.css` files all get compiled into one `<project-name>.styles.css` file. Let's copy that one to the src directory and import it from `index.tsx`.
