### PR TITLE
Add project name to scaffolding check

### DIFF
--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <Target Name="SetupPiral" BeforeTargets="Build">
-        <CallTarget Targets="Scaffold" Condition="!Exists('$(_piletFolderPath)')"/>
+        <CallTarget Targets="Scaffold" Condition="!Exists('$(_piletFolderPath)\$(MSBuildProjectName)')"/>
     </Target>
     
     <Target Name="Scaffold">


### PR DESCRIPTION
Works with a single `.csproj` & multiple projects in one `.sln`