### PR TITLE
add package json overwrites task and fix version replacement

### DIFF
--- a/src/Piral.Blazor.Tools/Piral.Blazor.Tools.csproj
+++ b/src/Piral.Blazor.Tools/Piral.Blazor.Tools.csproj
@@ -10,7 +10,7 @@
         <PackageLicenseUrl>https://github.com/smapiot/Piral.Blazor/blob/master/LICENSE</PackageLicenseUrl>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageProjectUrl>https://github.com/smapiot/Piral.Blazor</PackageProjectUrl>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -18,5 +18,10 @@
         <None Include="build\**" Pack="True" PackagePath="build\" />
         <None Include="content\**" Pack="True" PackagePath="content\" />
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> 
+    </ItemGroup> 
 
 </Project>

--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -1,13 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <ItemGroup>
-        <Content Update="wwwroot\**" CopyToOutputDirectory="Always" />
+	<UsingTask TaskName="SetProjectJsonVersionTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Piral.Blazor.Tools.dll" />
+	<UsingTask TaskName="AddProjectJsonOverwritesTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Piral.Blazor.Tools.dll" />
+	
+	<ItemGroup>
+        <Content Update="wwwroot\**" CopyToOutputDirectory="Always" /> 
     </ItemGroup>
     
     <PropertyGroup>
         <_piletFolderBase>..\piral~</_piletFolderBase>
         <_piletFolderPath>$(MSBuildProjectDirectory)\$(_piletFolderBase)\$(MSBuildProjectName)</_piletFolderPath>
-        <_piletUrl>http://localhost:1234</_piletUrl>
+        <_piletUrl>http://localhost:1234</_piletUrl> 
         <_srcPath>$(_piletFolderPath)\src</_srcPath>
         <_bundler>webpack5</_bundler>
     </PropertyGroup>
@@ -18,12 +21,23 @@
     
     <Target Name="Scaffold">
         <Exec Command="echo 'Scaffolding the pilet...'"/>
-        <Exec Command="npx --package=piral-cli -y pilet new $(PiralInstance) --base $(_piletFolderBase) --target $(MSBuildProjectName) --registry $(NpmRegistry) --bundler $(_bundler)"/>
+        <Exec Command="npx --package=piral-cli -y pilet new $(PiralInstance) --base $(_piletFolderBase) --target $(MSBuildProjectName) --registry $(NpmRegistry) --bundler $(_bundler) --no-install"/>
     </Target>
 
-    <Target Name="InstallDependencies" AfterTargets="Scaffold">
-        <Exec WorkingDirectory="$(_piletFolderPath)" Command="npm install"/>
-    </Target>
+	<Target Name="SetPackageJsonVersion" AfterTargets="Scaffold">
+		<Exec Command="echo 'Set version in package.json file...'"/>
+		<SetProjectJsonVersionTask PackageJsonPath="$(_piletFolderPath)\package.json" Version="$(Version)"  /> 
+	</Target>
+
+	<Target Name="AddPackageJsonOverwrites" AfterTargets="SetPackageJsonVersion">
+		<Exec Command="echo 'Add overwrites to package.json file...'"/>
+		<AddProjectJsonOverwritesTask PackageJsonPath="$(_piletFolderPath)\package.json" OverwritesPath="$(MSBuildProjectDirectory)\overwrite.package.json"  />
+	</Target>
+
+    <Target Name="InstallDependencies" AfterTargets="AddPackageJsonOverwrites">
+		<Exec Command="echo 'Installing dependencies...'"/>
+        <Exec WorkingDirectory="$(_piletFolderPath)" Command="npm install --silent"/> 
+    </Target> 
     
     <Target Name="DeleteIndexTsx" AfterTargets="Scaffold">
         <Delete Files="$(_srcPath)\index.tsx" />
@@ -40,8 +54,8 @@
                 Condition="!Exists('$(_piletFolderPath)\%(RecursiveDir)%(Filename)%(Extension)')"
         />
     </Target>
-        
-    <Target Name="ModifyIndexTsx" AfterTargets="CopyScaffoldFiles">
+
+	<Target Name="ModifyIndexTsx" AfterTargets="CopyScaffoldFiles">
         <Exec Command="echo 'Modifying the index file...'"/>
         <WriteLinesToFile
                 File="$(_srcPath)\index.tsx"
@@ -59,7 +73,7 @@
                 Encoding="UTF-8"/>
     </Target>
 
-    <Target Name="InstallAnalyzer" AfterTargets="CopyScaffoldFiles" DependsOnTargets="RunResolvePackageDependencies">
+	<Target Name="InstallAnalyzer" AfterTargets="CopyScaffoldFiles" DependsOnTargets="RunResolvePackageDependencies">
         <PropertyGroup>
             <_installedToolsVersion>@(PackageDefinitions->WithMetadataValue("Name", "Piral.Blazor.Tools")->'%(Version)')</_installedToolsVersion>
         </PropertyGroup>

--- a/src/Piral.Blazor.Tools/tasks/AddProjectJsonOverwritesTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/AddProjectJsonOverwritesTask.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+
+namespace Piral.Blazor.Tools.Tasks
+{
+    public class AddProjectJsonOverwritesTask : Task
+    {
+        [Required]
+        public string PackageJsonPath { get; set; }
+
+        [Required]
+        public string OverwritesPath { get; set; }
+
+        public override bool Execute()
+        {
+            //System.Diagnostics.Debugger.Launch(); 
+            try
+            { 
+                if (!File.Exists(PackageJsonPath)) {
+                    return false;
+                }
+                if (!File.Exists(OverwritesPath)) 
+                {
+                    return true;
+                }
+                var result = new JObject();
+
+                var packageJson = JObject.Parse(File.ReadAllText(PackageJsonPath)); 
+                var overwritesJson = JObject.Parse(File.ReadAllText(OverwritesPath)); 
+
+                result.Merge(packageJson); 
+                result.Merge(overwritesJson); 
+
+                File.WriteAllText(PackageJsonPath, JsonConvert.SerializeObject(result, Formatting.Indented));
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true; 
+        }
+    }
+}

--- a/src/Piral.Blazor.Tools/tasks/AddProjectJsonOverwritesTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/AddProjectJsonOverwritesTask.cs
@@ -21,10 +21,12 @@ namespace Piral.Blazor.Tools.Tasks
             try
             { 
                 if (!File.Exists(PackageJsonPath)) {
+                    Log.LogError("The file 'PackageJsonPath' does not exist."); 
                     return false;
                 }
                 if (!File.Exists(OverwritesPath)) 
                 {
+                    Log.LogWarning("No 'overwrite.package.json'-file found to merge into package.json.");
                     return true;
                 }
                 var result = new JObject();
@@ -37,8 +39,9 @@ namespace Piral.Blazor.Tools.Tasks
 
                 File.WriteAllText(PackageJsonPath, JsonConvert.SerializeObject(result, Formatting.Indented));
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Log.LogError(error.Message);
                 return false;
             }
             return true; 

--- a/src/Piral.Blazor.Tools/tasks/SetProjectJsonVersionTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/SetProjectJsonVersionTask.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+
+namespace Piral.Blazor.Tools.Tasks
+{
+    public class SetProjectJsonVersionTask : Task
+    {
+        [Required]
+        public string PackageJsonPath { get; set; }
+
+        [Required]
+        public string Version { get; set; }
+
+        public override bool Execute()
+        {
+            //System.Diagnostics.Debugger.Launch(); 
+            try
+            {
+                if (!File.Exists(PackageJsonPath))
+                {
+                    return false;
+                }
+                var packageJsonText = File.ReadAllText(PackageJsonPath); 
+                packageJsonText = packageJsonText.Replace(@"""version"": ""1.0.0""", $@"""version"": ""{Version}""");
+                File.WriteAllText(PackageJsonPath, packageJsonText); 
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true; 
+        }
+    }
+}

--- a/src/Piral.Blazor.Tools/tasks/SetProjectJsonVersionTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/SetProjectJsonVersionTask.cs
@@ -20,14 +20,16 @@ namespace Piral.Blazor.Tools.Tasks
             {
                 if (!File.Exists(PackageJsonPath))
                 {
+                    Log.LogError("The file 'PackageJsonPath' does not exist."); 
                     return false;
                 }
                 var packageJsonText = File.ReadAllText(PackageJsonPath); 
                 packageJsonText = packageJsonText.Replace(@"""version"": ""1.0.0""", $@"""version"": ""{Version}""");
-                File.WriteAllText(PackageJsonPath, packageJsonText); 
+                File.WriteAllText(PackageJsonPath, packageJsonText);
             }
-            catch (Exception)
+            catch (Exception error)
             {
+                Log.LogError(error.Message);  
                 return false;
             }
             return true; 


### PR DESCRIPTION
This will fix issue https://github.com/smapiot/Piral.Blazor/issues/56
since i needed newtonsoft to merge 2 json files i had to use a custom task. (this is also easier to debug)
In order to use custom msbuild tasks i had to install Microsoft.Build.Utilities.Core and set the TargetFramework to netstandard2.0.
It sook me a while to find that out. you can read more about it here (accepted answer):
https://docs.microsoft.com/en-us/answers/questions/459914/custom-buld-task-when-used-in-csproject-throws-39c.html
and here:
https://github.com/dotnet/msbuild/issues/5904#issuecomment-733877680

since my last PR (inserting the blazor projects version into package json) had some encoding problem i also fixed this by using a custom task here too.
The problem with my old sollution showed when running npm start in the blazor pilet. there it could not read the package json fole because of the &quot; signs i added.