### PR TITLE
add monorepo support for blazor pilets

### DIFF
--- a/src/Piral.Blazor.Tools/Piral.Blazor.Tools.csproj
+++ b/src/Piral.Blazor.Tools/Piral.Blazor.Tools.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
+      <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> 
     </ItemGroup> 
 

--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.props
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.props
@@ -5,5 +5,6 @@
         <NpmRegistry>https://registry.npmjs.org/</NpmRegistry>
         <Bundler>webpack5</Bundler>
         <ProjectsWithStaticFiles></ProjectsWithStaticFiles>
+        <Monorepo></Monorepo>
     </PropertyGroup>
 </Project>

--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -3,6 +3,7 @@
     <UsingTask TaskName="SetProjectJsonVersionTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Piral.Blazor.Tools.dll" />
     <UsingTask TaskName="AddProjectJsonOverwritesTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Piral.Blazor.Tools.dll" />
     <UsingTask TaskName="CollectStaticWebAssetsTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Piral.Blazor.Tools.dll" />
+    <UsingTask TaskName="SetMonorepoPiralInstanceTask" AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Piral.Blazor.Tools.dll" />
 
     <ItemGroup>
         <Content Update="wwwroot\**" CopyToOutputDirectory="Always" />
@@ -41,9 +42,19 @@
         <CollectStaticWebAssetsTask AssetPath="%(StaticWebAsset.Identity)" TargetPath="$(_srcPath)/_content" ProjectsWithStaticFiles="$(ProjectsWithStaticFiles)" />
     </Target>
 
-    <Target Name="InstallDependencies" AfterTargets="AddPackageJsonOverwrites">
+    <Target Name="InstallDependencies" AfterTargets="AddPackageJsonOverwrites" Condition="'$(Monorepo)'!='enable'">
         <Exec Command="echo 'Installing dependencies...'" />
         <Exec WorkingDirectory="$(_piletFolderPath)" Command="npm install --silent" />
+    </Target>
+
+	<Target Name="RemoveNodeModulesAndLockFile" AfterTargets="InstallDependencies" Condition="'$(Monorepo)'=='enable'"> 
+		<RemoveDir Directories="$(_piletFolderPath)\node_modules" />
+		<Delete Files="$(_piletFolderPath)\package-lock.json" />
+	</Target>
+
+    <Target Name="SetMonorepoAppShell" AfterTargets="RemoveNodeModulesAndLockFile">
+        <Exec Command="echo 'Symlinking to the piral instance inside the monorepo...'" />
+        <SetMonorepoPiralInstanceTask PiralInstancePath="$(PiralInstance)" PiletPath="$(_piletFolderPath)" />
     </Target>
 
     <Target Name="DeleteIndexTsx" AfterTargets="Scaffold">

--- a/src/Piral.Blazor.Tools/content/src/blazor.codegen
+++ b/src/Piral.Blazor.Tools/content/src/blazor.codegen
@@ -34,7 +34,10 @@ const sourceDir = resolve(wwwRootDir, '_framework');
 const projectAssets = require(resolve(objectsDir, pajson));
 
 const project = require(resolve(piralPiletFolder, pjson));
-const appdir = resolve(piralPiletFolder, 'node_modules', project.piral.name);
+let appdir = resolve(piralPiletFolder, 'node_modules', project.piral.name);
+if(!existsSync(appdir + '/app') && existsSync(appdir + '/dist')){
+  appdir = appdir + "/dist";
+}
 const appFrameworkDir = resolve(appdir, 'app', '_framework');
 const piletManifest = require(resolve(sourceDir, bbjson));
 const piralVersion = getPiralVersion();

--- a/src/Piral.Blazor.Tools/models/PackageJsonObject.cs
+++ b/src/Piral.Blazor.Tools/models/PackageJsonObject.cs
@@ -1,0 +1,6 @@
+namespace Piral.Blazor.Tools.Models
+{
+    public class PackageJsonObject{
+        public string Version { get; set; }
+    }
+}

--- a/src/Piral.Blazor.Tools/tasks/SetMonorepoPiralInstanceTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/SetMonorepoPiralInstanceTask.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Converters;
+using System;
+using System.IO;
+using System.Dynamic;
+using Piral.Blazor.Tools.Models;
+
+namespace Piral.Blazor.Tools.Tasks
+{
+    public class SetMonorepoPiralInstanceTask : Task
+    {
+        [Required]
+        public string PiralInstancePath { get; set; }
+
+        [Required]
+        public string PiletPath { get; set; }
+
+        public override bool Execute()
+        {
+            // System.Diagnostics.Debugger.Launch(); 
+            try
+            {
+                var piletPackageJsonFile = $"{PiletPath}/package.json";
+
+                if (!File.Exists(piletPackageJsonFile))
+                {
+                    Log.LogError($"Could not find pilet package.json file here:'{piletPackageJsonFile}'."); 
+                    return false;
+                }
+
+                var piralInstanceVersion = GetPiralInstanceVersion();
+                var piralInstancePathInPackageJson = $"file:..\\\\{PiralInstancePath.Replace("\\", "\\\\").Replace("/", "\\\\")}";
+
+                var piletPackageJsonText = File.ReadAllText(piletPackageJsonFile); 
+                piletPackageJsonText = piletPackageJsonText.Replace(piralInstancePathInPackageJson, piralInstanceVersion);
+                File.WriteAllText(piletPackageJsonFile, piletPackageJsonText); 
+            }
+            catch (Exception error)
+            {
+                Log.LogError(error.Message);  
+                return false;
+            }
+            return true; 
+        }
+
+        private dynamic GetPiralInstanceVersion(){
+            var emulatorDirectory = Path.GetDirectoryName(PiralInstancePath);
+            var piralInstanceDirectory = emulatorDirectory.Replace("\\dist\\emulator", "");
+            var piralInstancePackageJsonFile = $"{piralInstanceDirectory}/package.json";
+            
+            if (!File.Exists(piralInstancePackageJsonFile)) {
+                Log.LogError($"Could not find piral instance package.json file here:'{piralInstancePackageJsonFile}'."); 
+                throw new FileNotFoundException();
+            }
+
+            var piralInstancePackageJsonData = JsonConvert.DeserializeObject<PackageJsonObject>(File.ReadAllText(piralInstancePackageJsonFile));
+            return piralInstancePackageJsonData.Version; 
+        }
+    }
+}


### PR DESCRIPTION
This adds a monorepo option.
If enabled the following things are done:
- the depenmdencies are not installed
- the app shells version will be read from the package inside the monorepo and will be placed inside the pilets dependencies
- the appdir is updated inside blazor.codegen

I tested this with a rush repo. can't tell if it'll work with lerna, but i think it will at least benefit lerna as well.