### PR TITLE
fix directory check for monorepos

### DIFF
--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -102,7 +102,7 @@
         <Exec WorkingDirectory="$(_piletFolderPath)" Command="dotnet tool install Piral.Blazor.Analyzer --version $(_installedToolsVersion) --local" />
     </Target>
 
-    <Target Name="RestoreTools" BeforeTargets="Build" Condition="Exists('$(_piletFolderPath)\..\.config\dotnet-tools.json')">
+    <Target Name="RestoreTools" BeforeTargets="Build" Condition="Exists('$(_piletFolderPath)') AND Exists('$(_piletFolderPath)\..\.config\dotnet-tools.json')">
         <Exec WorkingDirectory="$(_piletFolderPath)" Command="dotnet tool restore" />
     </Target>
 


### PR DESCRIPTION
this is needed because in a monorepo dotnet-tools.json might already exist from building another pilet but the current pilets folder is not yet created