### PR TITLE
Fixes/add js files from referenced packages

### DIFF
--- a/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
+++ b/src/Piral.Blazor.Tools/build/Piral.Blazor.Tools.targets
@@ -54,8 +54,9 @@
     <Target Name="CollectStaticWebAssets" AfterTargets="SetPackageJsonVersion">
         <CollectStaticWebAssetsTask
             AssetPath="%(StaticWebAsset.Identity)"
-            TargetPath="$(_piletFolderPath)\src\_content"
-            ProjectsWithStaticFiles="$(ProjectsWithStaticFiles)" />
+            TargetPath="$(_piletFolderPath)\src"
+            ProjectsWithStaticFiles="$(ProjectsWithStaticFiles)"
+            JsImportsPath="$(MSBuildProjectDirectory)\jsImports.json" />
     </Target>
 
     <Target Name="InstallDependencies" AfterTargets="AddPackageJsonOverwrites" Condition="'$(Monorepo)'!='enable'">

--- a/src/Piral.Blazor.Tools/tasks/CollectStaticWebAssetsTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/CollectStaticWebAssetsTask.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Piral.Blazor.Tools.Tasks
@@ -16,10 +18,12 @@ namespace Piral.Blazor.Tools.Tasks
         [Required]
         public string[] ProjectsWithStaticFiles { get; set; }
 
+        [Required]
+        public string JsImportsPath { get; set; }
+
         public override bool Execute()
         {
             Log.LogMessage($"Copying static web assets to blazor project via task...");
-
             try
             {
                 foreach (string projectName in ProjectsWithStaticFiles)
@@ -27,16 +31,37 @@ namespace Piral.Blazor.Tools.Tasks
                     if (AssetPath.Contains(projectName))
                     {
                         var fileName = Path.GetFileName(AssetPath);
-                        var folderName = Path.Combine(TargetPath, projectName);
-                        var filePath = Path.Combine(folderName, fileName);
+                        var folderName = $"{TargetPath}/_content/{projectName}/"; 
+                        var sourcePath = AssetPath.Replace(fileName, "");
+                        var jsImports = JsonConvert.DeserializeObject<List<string>>(File.ReadAllText(JsImportsPath)); 
 
                         if (!Directory.Exists(folderName))
                         {
                             Directory.CreateDirectory(folderName);
                         }
 
-                        File.Copy(AssetPath, filePath, true); 
-                        Log.LogMessage($"File '{AssetPath}' copied to '{filePath}'.");  
+                        // copy all directories
+                        foreach (string dirPath in Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories))
+                        {
+                            Directory.CreateDirectory(dirPath.Replace(sourcePath, folderName));
+                        }
+
+                        // copy all files
+                        foreach (string filePath in Directory.GetFiles(sourcePath, "*.*",SearchOption.AllDirectories))
+                        {
+                            File.Copy(filePath, filePath.Replace(sourcePath, folderName), true);
+                        }
+
+                        var jsImportsString = "";
+                        foreach (var jsImport in jsImports)
+                        {
+                            jsImportsString += $"import '{jsImport}';\n";
+                        }
+
+                        var indexTsxFielPath = $"{TargetPath}/index.tsx";
+                        File.WriteAllText(indexTsxFielPath, jsImportsString + File.ReadAllText(indexTsxFielPath));
+
+                        Log.LogMessage($"'{AssetPath}' copied to '{folderName}'.");  
                     }
                 }
             }

--- a/src/Piral.Blazor.Tools/tasks/CollectStaticWebAssetsTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/CollectStaticWebAssetsTask.cs
@@ -52,13 +52,15 @@ namespace Piral.Blazor.Tools.Tasks
                             File.Copy(filePath, filePath.Replace(sourcePath, folderName), true);
                         }
 
+                        var indexTsxFielPath = $"{TargetPath}/index.tsx";
                         var jsImportsString = "";
                         foreach (var jsImport in jsImports)
                         {
-                            jsImportsString += $"import '{jsImport}';\n";
+                            if(!File.ReadAllText(indexTsxFielPath).Contains($"import '{jsImport}';"))
+                            {
+                                jsImportsString += $"import '{jsImport}';\n";
+                            }
                         }
-
-                        var indexTsxFielPath = $"{TargetPath}/index.tsx";
                         File.WriteAllText(indexTsxFielPath, jsImportsString + File.ReadAllText(indexTsxFielPath));
 
                         Log.LogMessage($"'{AssetPath}' copied to '{folderName}'.");  
@@ -70,7 +72,7 @@ namespace Piral.Blazor.Tools.Tasks
                 Log.LogError(error.Message);  
                 return false;
             }
-
+            
             return true; 
         }
     }


### PR DESCRIPTION
Since our component library now has js files i found that there is currently no way to use them.

With these changes all assets in the _content folder are copied over.

Js files can then be added via a file "jsImports.json".
This file can look something like that:
```
[
  "./_content/MyOrg.Components/js/all.min.js",
  "./_content/MyOrg.Components/js/fontawesome.min.js"
]
```