### PR TITLE
Moved copying of config files before installation

### DIFF
--- a/src/Piral.Blazor.Tools/tasks/ManagePiletTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/ManagePiletTask.cs
@@ -201,13 +201,13 @@ namespace Piral.Blazor.Tools
 
             if (File.Exists(existingConfigFile))
             {
-                Log.LogWarning($"Ignoring NpmRegistry property! Copying file '{configFileName}' from '{existingConfigFile}'.");
+                Log.LogMessage($"Taking '{configFileName}' from '{existingConfigFile}'.");
                 var targetFile = Path.Combine(target, configFileName);
                 File.Copy(existingConfigFile, targetFile, true);
             }
             else
             {
-                Log.LogMessage($"Creating '{configFileName}' with provided NpmRegistry property.");
+                Log.LogMessage($"Creating '{configFileName}' with entry from NpmRegistry.");
                 File.AppendAllLines(Path.Combine(target, configFileName), [$"registry={NpmRegistry}", "always-auth=true"], Encoding.UTF8);
             }
         }

--- a/src/Piral.Blazor.Tools/tasks/ManagePiletTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/ManagePiletTask.cs
@@ -191,24 +191,24 @@ namespace Piral.Blazor.Tools
             return 0;
         }
 
-        private void CopyConfigurationFiles()
+        private void InitializeNpmConfiguration()
         {
-            var configurationFiles = new[] { ".npmrc" };
+            var configFileName = ".npmrc";
             var source = ConfigDir;
             var target = ProjectDir;
 
-            Log.LogMessage($"Copying config files from '{source}'...");
+            var existingConfigFile = Path.Combine(source, configFileName);
 
-            foreach (var configurationFile in configurationFiles)
+            if (File.Exists(existingConfigFile))
             {
-                var sourceFile = Path.Combine(source, configurationFile);
-
-                if (File.Exists(sourceFile))
-                {
-                    var targetFile = Path.Combine(target, configurationFile);
-                    Log.LogMessage($"Copying file '{configurationFile}' from '{sourceFile}'.");
-                    File.Copy(sourceFile, targetFile, true);
-                }
+                Log.LogWarning($"Ignoring NpmRegistry property! Copying file '{configFileName}' from '{existingConfigFile}'.");
+                var targetFile = Path.Combine(target, configFileName);
+                File.Copy(existingConfigFile, targetFile, true);
+            }
+            else
+            {
+                Log.LogMessage($"Creating '{configFileName}' with provided NpmRegistry property.");
+                File.AppendAllLines(Path.Combine(target, configFileName), [$"registry={NpmRegistry}", "always-auth=true"], Encoding.UTF8);
             }
         }
 
@@ -403,10 +403,13 @@ namespace Piral.Blazor.Tools
             }
 
             Directory.CreateDirectory(target);
+
+            InitializeNpmConfiguration();
+
             Run("npm", npm, target, $"{npmPrefix}init -y");
             Run("npm", npm, target, $"{npmPrefix}install piral-cli@{CliVersion} --save-dev");
             Run("npm", npm, target, $"{npmPrefix}install piral-cli-{Bundler}@{bundlerVersion} --save-dev");
-            Run("piral-cli", npx, target, $"{npxPrefix}pilet new \"{Emulator}\" --registry \"{NpmRegistry}\" --bundler none --no-install");
+            Run("piral-cli", npx, target, $"{npxPrefix}pilet new \"{Emulator}\" --bundler none --no-install");
 
             ChangeOutputDirectory();
 
@@ -456,7 +459,7 @@ namespace Piral.Blazor.Tools
             }
 
             var json = JObject.Parse(File.ReadAllText(packageJsonFile));
-            
+
             if (!string.IsNullOrEmpty(Version))
             {
                 json["version"] = Version;
@@ -510,7 +513,7 @@ namespace Piral.Blazor.Tools
         {
             if (string.IsNullOrEmpty(name))
             {
-                name = "pilet";                
+                name = "pilet";
             }
 
             name = name.ToLowerInvariant();
@@ -564,7 +567,7 @@ namespace Piral.Blazor.Tools
                 throw new Exception($"The file '{originalJsonFile}' does not exist.");
             }
 
-            if (!File.Exists(overwritesJsonFile)) 
+            if (!File.Exists(overwritesJsonFile))
             {
                 Log.LogMessage($"No '{target}' file found to merge into '{source}'.");
                 return;
@@ -576,10 +579,10 @@ namespace Piral.Blazor.Tools
             }
 
             var result = new JObject();
-            var originalJson = JObject.Parse(File.ReadAllText(backup)); 
-            var overwritesJson = JObject.Parse(File.ReadAllText(overwritesJsonFile)); 
+            var originalJson = JObject.Parse(File.ReadAllText(backup));
+            var overwritesJson = JObject.Parse(File.ReadAllText(overwritesJsonFile));
 
-            result.Merge(originalJson); 
+            result.Merge(originalJson);
             result.Merge(overwritesJson);
 
             File.WriteAllText(originalJsonFile, JsonConvert.SerializeObject(result, Formatting.Indented));
@@ -617,8 +620,6 @@ namespace Piral.Blazor.Tools
 
                 if (canScaffold)
                 {
-                    CopyConfigurationFiles();
-                    
                     var requireInstall = PreparePilet();
 
                     if (requireInstall)

--- a/src/Piral.Blazor.Tools/tasks/ManagePiletTask.cs
+++ b/src/Piral.Blazor.Tools/tasks/ManagePiletTask.cs
@@ -617,9 +617,9 @@ namespace Piral.Blazor.Tools
 
                 if (canScaffold)
                 {
-                    var requireInstall = PreparePilet();
-
                     CopyConfigurationFiles();
+                    
+                    var requireInstall = PreparePilet();
 
                     if (requireInstall)
                     {


### PR DESCRIPTION
# New Pull Request

## Prerequisites

Please make sure you can check the following boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] All new and existing tests passed

## Type(s) of Changes

### Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes

### Description

Fixes #133 

Moved step regarding copying config files (.npmrc) before `npx pilet new` is executed so in case if shell app is in private npm feed that requires authentication, `.npmrc` is copied on time.

### Remarks

This PR is for `blazor7.0`, but will also create PR for `blazor8.0` branch once this gets approved and merged.
